### PR TITLE
Amazon linux base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3-alpine
+FROM amazonlinux:2
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh gcc build-base libffi-dev"]
+RUN ["/bin/sh", "-c", "yum install -y --update --no-cache python3 python3-pip bash ca-certificates curl git jq openssh gcc build-base libffi-devel"]
 # gcc and build is required to build python packages on the fly
 
 COPY ["src", "/src/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-RUN ["/bin/sh", "-c", "yum install -y python3 python3-pip bash ca-certificates curl git jq openssh gcc build-base libffi-devel"]
+RUN ["/bin/sh", "-c", "yum install -y python3 python3-pip bash ca-certificates curl git jq openssh gcc build-base libffi-devel unzip"]
 # gcc and build is required to build python packages on the fly
 
 COPY ["src", "/src/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-RUN ["/bin/sh", "-c", "yum install -y --update --no-cache python3 python3-pip bash ca-certificates curl git jq openssh gcc build-base libffi-devel"]
+RUN ["/bin/sh", "-c", "yum install -y python3 python3-pip bash ca-certificates curl git jq openssh gcc build-base libffi-devel"]
 # gcc and build is required to build python packages on the fly
 
 COPY ["src", "/src/"]

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,9 @@ inputs:
   tf_actions_working_dir:
     description: 'Terraform working directory.'
     default: '.'
-outputs:
+  args:
+    description: 'Terraform arguments like -var-file'
+  outputs:
   tf_actions_output:
     description: 'The Terraform outputs in JSON format.'
   tf_actions_plan_has_changes:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: '.'
   args:
     description: 'Terraform arguments like -var-file'
-  outputs:
+outputs:
   tf_actions_output:
     description: 'The Terraform outputs in JSON format.'
   tf_actions_plan_has_changes:


### PR DESCRIPTION
We need to change the base build container to Amazon Linux.
Lambda functions are running on a AL based container and when python modules have to be compiled it must be compiled on that otherwise Lambda runtime can't find libraries.
It happened to the Keyrotate Lambda.

We could think about creating our container and storing it in Dockerhub or AWS ECR so it doesn't have to be built on the fly with every action run. Same as the "ecs-deploy" container.